### PR TITLE
Improvements for XHTML/HTML5 specifications.

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html lang="{{ site.lang | default: "en-US" }}">
   <head>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="chrome=1">
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="chrome=1"/>
     <title>{{ site.title | default: site.github.repository_name }} by {{ site.github.owner_name }}</title>
 
-    <link rel="stylesheet" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
-    <meta name="viewport" content="width=device-width">
+    <link rel="stylesheet" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}"/>
+    <meta name="viewport" content="width=device-width"/>
     <!--[if lt IE 9]>
     <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->

--- a/ui/QuickFormToolTemplate.html
+++ b/ui/QuickFormToolTemplate.html
@@ -12,7 +12,7 @@
                         <li class="qft-radiobutton" title="Radio Button"><img /></li>
                         <li class="qft-hiddenfield" title="Hidden Input"><img /></li>
                         <li class="qft-textarea" title="Text Area"><img /></li>
-                        <li class="qft-imagefield" title="Image <img .."><img /></li>
+                        <li class="qft-imagefield" title="Image <img .."/><img /></li>
                         <li class="qft-imagebutton" title="Image Button"><img /></li>
                         <li class="qft-form" title="Form"><img /></li>
                     </ul>


### PR DESCRIPTION
**Introduction:**
In accordance with the w3 HTML5 specification for HTML code, void tags (see reference) should be marked as self-closing. During a scan for repositories containing HTML files, we found HTML code in your repository that needed this improvement.

Even though the self-closing specification is not a strict requirement by web-browsers, and they will happily parse the tag anyhow - that is not an excuse for not writing specification valid code, and I am more than happy to help correct this. In the spirit of an open-source community! The changes in this PullRequest will not break your code in any way.

**References:**
https://www.w3.org/TR/html5/syntax.html#void-elements
