### PR TITLE
Remove file format check & Make toolbar ergonomic again

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# QuickFormTool # ver 2.7.1
+# QuickFormTool # ver 2.7.2
 
 An extension for Adobe Brackets to insert form elements into editor quickly.<br>
 This extension now available for download.<br>

--- a/main.js
+++ b/main.js
@@ -206,16 +206,13 @@ define(function (require, exports, module)
       fileFullName = fileFullPath.substring(fileFullPath.lastIndexOf("/") + 1), 
       fileFormat = fileFullName.substring(fileFullName.lastIndexOf(".") + 1);
 
-      if (fileFormat == "html" || fileFormat == "htm")
-      {
-        EditorManager.getFocusedEditor();
-        var getDocumentText_ = activeEditor.document.getText().replace("</" + tag + ">", "\t" + text + "\n</" + tag + ">");
-        activeEditor.document.setText(getDocumentText_);    
-                //activeEditor.document.replaceRange(text, activeEditor.getCursorPos());
-              }
-            }
-            catch(err){alert("Error: "+err);}
-          }
+      EditorManager.getFocusedEditor();
+      var getDocumentText_ = activeEditor.document.getText().replace("</" + tag + ">", "\t" + text + "\n</" + tag + ">");
+      activeEditor.document.setText(getDocumentText_);    
+      //activeEditor.document.replaceRange(text, activeEditor.getCursorPos());
+    }
+    catch(err){alert("Error: "+err);}
+  }
 
     //make new document. used of document/DocumentManager -> createUntitledDocument()
     function createUntitledDocument(filename, counter, fileExt) {

--- a/main.js
+++ b/main.js
@@ -180,7 +180,7 @@ define(function (require, exports, module)
       fileFullName = fileFullPath.substring(fileFullPath.lastIndexOf("/") + 1), 
       fileFormat = fileFullName.substring(fileFullName.lastIndexOf(".") + 1);
 
-      if (fileFormat == "html" || fileFormat == "htm")
+      if (fileFormat != "css")
       {
         var line = activeEditor.document.getLine(activeEditor.getCursorPos().line);
         if (line.replace(/^\s+|\s+$/g, '').length>0)

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "title": "QuickFormTool",
     "description": "Insert form elements quickly",
     "homepage": "https://github.com/mohammadyaghobi/Brackets-QuickFormTool",
-    "version": "2.7",
+    "version": "2.7.2",
     "author": "Mohammad Yaghobi <m.yaghobi.abc@gmail.com>",
     "license": "MIT",
     "repository": {

--- a/ui/style.css
+++ b/ui/style.css
@@ -104,14 +104,14 @@
 .qftnotify
 {
     position: absolute;
-    right: 4px;
+    right: 20px;
     cursor:pointer;
     background: #47484b url(images/notify-down.png) no-repeat center;
     box-shadow: inset 0 2px 6px 0 rgba(0, 0, 0, 0.4);
     z-index: 1000;
     margin: 0 0 -10px 0 ;
-    height: 30px;
-    width: 60px;
+    height: 14px;
+    width: 26px;
     transition: all 0.2s;
 	-webkit-transition: all 0.2s;
 	-o-transition: all 0.2s;
@@ -121,7 +121,7 @@
 .qftnotify-exp
 {
     margin-top: 31px;
-    height: 30px;
+    height: 13px;
     box-shadow: inset 0 2px 8px 0 rgba(0, 0, 0, 1);
     background: #47484b url(images/notify-up.png) no-repeat center;
 }
@@ -130,7 +130,7 @@
     opacity: 0.8;
     position:absolute;
     top: 0;
-    right: 4px;
+    right: 12px;
     overflow:hidden;
     z-index: 4;
     min-width: 23px;
@@ -152,6 +152,7 @@
     width:auto;
     height: 30px;
 	box-shadow: none;
+    right:17px;
     opacity: 1;
     margin-top: 0;
     background-image: none;
@@ -159,6 +160,7 @@
 
 .qftblock:hover
 {
+    right: 17px;
     height: 30px;
     width:inherit;
 	box-shadow: none;

--- a/ui/style.css
+++ b/ui/style.css
@@ -104,14 +104,14 @@
 .qftnotify
 {
     position: absolute;
-    right: 20px;
+    right: 4px;
     cursor:pointer;
     background: #47484b url(images/notify-down.png) no-repeat center;
     box-shadow: inset 0 2px 6px 0 rgba(0, 0, 0, 0.4);
-    z-index: 2;
+    z-index: 1000;
     margin: 0 0 -10px 0 ;
-    height: 14px;
-    width: 26px;
+    height: 30px;
+    width: 60px;
     transition: all 0.2s;
 	-webkit-transition: all 0.2s;
 	-o-transition: all 0.2s;
@@ -121,7 +121,7 @@
 .qftnotify-exp
 {
     margin-top: 31px;
-    height: 13px;
+    height: 30px;
     box-shadow: inset 0 2px 8px 0 rgba(0, 0, 0, 1);
     background: #47484b url(images/notify-up.png) no-repeat center;
 }
@@ -130,7 +130,7 @@
     opacity: 0.8;
     position:absolute;
     top: 0;
-    right: 12px;
+    right: 4px;
     overflow:hidden;
     z-index: 4;
     min-width: 23px;
@@ -152,7 +152,6 @@
     width:auto;
     height: 30px;
 	box-shadow: none;
-    right:17px;
     opacity: 1;
     margin-top: 0;
     background-image: none;
@@ -160,7 +159,6 @@
 
 .qftblock:hover
 {
-    right: 17px;
     height: 30px;
     width:inherit;
 	box-shadow: none;


### PR DESCRIPTION
- Removes the file format check to allow use in others files like .php (fixes #8)
- Makes toolbar ergonomic again by bypassing extensions like https://github.com/zorgzerg/brackets-minimap or https://github.com/demonmhon/brackets-working-file-tabs (fixes #7)